### PR TITLE
Turn off Study List link on viewer page

### DIFF
--- a/static_files/app-config-template.js
+++ b/static_files/app-config-template.js
@@ -3,7 +3,7 @@ window.config = {
   routerBasename: '/',
   whiteLabelling: {},
   extensions: [],
-  showStudyList: true,
+  showStudyList: false,
   filterQueryParam: true,
   httpErrorHandler: error => {
     // This is 429 when rejected from the public idc sandbox too often.


### PR DESCRIPTION
This config option should be off for IDC since we don't want users to get to the study list from the viewer page.  Instead they should close the tab and they will be back at the IDC portal.