### PR TITLE
Remove redundant witeLabel key from app-config

### DIFF
--- a/static_files/app-config-template.js
+++ b/static_files/app-config-template.js
@@ -1,7 +1,6 @@
 window.config = {
   // default: '/'
   routerBasename: '/',
-  whiteLabelling: {},
   extensions: [],
   disableMeasurementPanel: true,
   splitQueryParameterCalls: true,


### PR DESCRIPTION
Could cause confusion to have it defined twice (differently)