### PR TITLE
set redirect for logo

### DIFF
--- a/static_files/app-config-template.js
+++ b/static_files/app-config-template.js
@@ -136,7 +136,7 @@ window.config = {
         target: '_self',
         rel: 'noopener noreferrer',
         className: 'header-brand',
-        href: '/',
+        href: 'https://imagingdatacommons.github.io/',
         style: {
           display: 'block',
           textIndent: '-9999px',


### PR DESCRIPTION
As discussed the '/' route gives an error in the IDC deployment so route people back to the project site instead